### PR TITLE
Cert optional blocks

### DIFF
--- a/alb.tf
+++ b/alb.tf
@@ -11,6 +11,7 @@ resource "aws_alb" "app_alb" {
 
 #TODO
 resource "aws_route53_record" "alb_endpoint" {
+  count = var.domain_name ? 1 : 0
   zone_id = var.zone_id
   name    = var.domain_name
   type    = "A"

--- a/alb.tf
+++ b/alb.tf
@@ -24,35 +24,35 @@ resource "aws_route53_record" "alb_endpoint" {
 }
 
 #going to add in all the route53 stuff here, including ACM stuff.
-#resource "aws_acm_certificate" "cert_request" {
-#  domain_name               = var.domain_name
-#  validation_method         = "DNS"
+resource "aws_acm_certificate" "cert_request" {
+  domain_name               = var.domain_name
+  validation_method         = "DNS"
 
-#  tags = {
-#    Name : var.domain_name
-#  }
+  tags = {
+    Name : var.domain_name
+  }
 
-#  lifecycle {
-#    create_before_destroy = true
-#  }
-#}
+  lifecycle {
+    create_before_destroy = true
+  }
+}
 
-#resource "aws_route53_record" "validation_record" {
-#  for_each = {
-#    for dvo in aws_acm_certificate.cert_request.domain_validation_options : dvo.domain_name => {
-#      name   = dvo.resource_record_name
-#      record = dvo.resource_record_value
-#      type   = dvo.resource_record_type
-#    }
-#  }
+resource "aws_route53_record" "validation_record" {
+  for_each = {
+    for dvo in aws_acm_certificate.cert_request.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
 
-#  allow_overwrite = true
-#  name            = each.value.name
-#  records         = [each.value.record]
-#  ttl             = var.ttl
-#  type            = each.value.type
-#  zone_id         = aws_route53_zone.main_zone.zone_id
-#}
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  #ttl             = var.ttl
+  type            = each.value.type
+  zone_id         = var.zone_id
+}
 
 #resource "aws_acm_certificate_validation" "certificate_validation" {
 #  certificate_arn         = aws_acm_certificate.cert_request.arn
@@ -101,6 +101,24 @@ resource "aws_alb_listener" "web_app_http" {
   load_balancer_arn = aws_alb.app_alb.arn
   port              = "80"
   protocol          = "HTTP"
+  depends_on        = [aws_alb_target_group.api_target_group]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  default_action {
+    target_group_arn = aws_alb_target_group.api_target_group.arn
+    type             = "forward"
+  }
+}
+
+resource "aws_alb_listener" "web_app_https" {
+  #count = local.is_only_http ? 1 : 0
+  count = var.use_cert ? 1 : 0
+  load_balancer_arn = aws_alb.app_alb.arn
+  port              = "443"
+  protocol          = "HTTPS"
   depends_on        = [aws_alb_target_group.api_target_group]
 
   lifecycle {

--- a/alb.tf
+++ b/alb.tf
@@ -80,6 +80,7 @@ resource "aws_alb_target_group" "api_target_group" {
 
 resource "aws_alb_listener" "web_app" {
   #count             = local.can_ssl ? 0 : 1
+  count = var.use_cert ? 0 : 1
   load_balancer_arn = aws_alb.app_alb.arn
   port              = var.alb_port
   protocol          = "HTTP"

--- a/alb.tf
+++ b/alb.tf
@@ -49,7 +49,7 @@ resource "aws_route53_record" "validation_record" {
   allow_overwrite = true
   name            = each.value.name
   records         = [each.value.record]
-  #ttl             = var.ttl
+  ttl             = 60
   type            = each.value.type
   zone_id         = var.zone_id
 }

--- a/alb.tf
+++ b/alb.tf
@@ -97,6 +97,7 @@ resource "aws_alb_listener" "web_app" {
 
 resource "aws_alb_listener" "web_app_http" {
   #count = local.is_only_http ? 1 : 0
+  count = var.use_cert ? 0 : 1
 
   load_balancer_arn = aws_alb.app_alb.arn
   port              = "80"
@@ -113,8 +114,24 @@ resource "aws_alb_listener" "web_app_http" {
   }
 }
 
+resource "aws_alb_listener" "http_forward" {
+  count = var.use_cert ? 1 : 0
+  load_balancer_arn = aws_alb.app_alb.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
 resource "aws_alb_listener" "web_app_https" {
-  #count = local.is_only_http ? 1 : 0
   count = var.use_cert ? 1 : 0
   load_balancer_arn = aws_alb.app_alb.arn
   port              = "443"

--- a/alb.tf
+++ b/alb.tf
@@ -11,7 +11,7 @@ resource "aws_alb" "app_alb" {
 
 #TODO
 resource "aws_route53_record" "alb_endpoint" {
-  count = var.domain_name ? 1 : 0
+  count = var.use_cert ? 1 : 0
   zone_id = var.zone_id
   name    = var.domain_name
   type    = "A"

--- a/alb.tf
+++ b/alb.tf
@@ -119,6 +119,8 @@ resource "aws_alb_listener" "web_app_https" {
   load_balancer_arn = aws_alb.app_alb.arn
   port              = "443"
   protocol          = "HTTPS"
+  certificate_arn = aws_acm_certificate.cert_request.arn
+  ssl_policy = "ELBSecurityPolicy-2016-08"
   depends_on        = [aws_alb_target_group.api_target_group]
 
   lifecycle {

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,5 +11,5 @@ output "alb_endpoint" {
 }
 
 output "url" {
-    value = aws_route53_record.alb_endpoint.name
+    value = aws_route53_record.alb_endpoint[0].name
 }

--- a/security_group.tf
+++ b/security_group.tf
@@ -56,7 +56,7 @@ resource "aws_security_group_rule" "https" {
   protocol          = "tcp"
   cidr_blocks       = [var.external_ip]
   security_group_id = aws_security_group.alb_sg.id
-  depends_on = [aws_security_group.alb_sg]
+  #depends_on = [aws_security_group.alb_sg]
 }
 
 # ECS Cluster Security Group

--- a/variables.tf
+++ b/variables.tf
@@ -70,9 +70,12 @@ variable "zone_id" {
 
 variable "domain_name" {
     description = "domain name to be used for the alb"
+    default = ""
 }
 
 variable "use_cert" {
     type = bool
-    description = "true/false as to our use of a certificate"
+    description = "true/false as to our use of a certificate. requires domain name"
 }
+
+


### PR DESCRIPTION
- integrated support for route53 domain with acm cert
- also supports comms over just http, albeit without domain at this point